### PR TITLE
Deprecation warnings for Amiga OS v1.x -> v2.x transition

### DIFF
--- a/website/docs/amiga_quick_start/amiga-quick-start.md
+++ b/website/docs/amiga_quick_start/amiga-quick-start.md
@@ -87,6 +87,11 @@ To do this you will need to go to the:
 
 ### Overview the Brain
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This video only applies to brains running Amiga OS `v1.x` versions.
+:::
+
 <iframe width="560" height="315"
 src="https://www.youtube.com/embed/_p0I11p4QF4?list=PLWQmpzk0y9NDXFKSwvCjYtRL8QNWfK4ND"
 title="Amiga Brain Overview" frameborder="0"

--- a/website/docs/brain/README.md
+++ b/website/docs/brain/README.md
@@ -3,6 +3,11 @@ id: brain
 title: Brain v1.0
 ---
 
+:::info
+The Brain v1.0 tag here refers to the **hardware** version of the brain
+and is not mutually exclusive with Amiga OS software versioning.
+:::
+
 ![brain_render](./assets/brain_render_iso.png)
 
 :::tip
@@ -10,6 +15,11 @@ Find additional information and purchasing options at: [**Brain product page**](
 :::
 
 ## Brain overview video
+
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This video only applies to brains running Amiga OS `v1.x` versions.
+:::
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/_p0I11p4QF4"
 title="YouTube video player" frameborder="0"

--- a/website/docs/brain/brain-install.md
+++ b/website/docs/brain/brain-install.md
@@ -26,7 +26,7 @@ package and test the available examples, start by cloning the
 repo:
 
 ```bash
-git clone git@github.com:farm-ng/farm-ng-amiga.git
+git clone https://github.com/farm-ng/farm-ng-amiga.git
 cd farm-ng-amiga/
 ```
 
@@ -38,23 +38,15 @@ git checkout main
 git pull
 ```
 
-:::caution troubleshooting
-If you have trouble cloning this public repo, Github is likely
-not able to authenticate your SSH public key.
-
-If this is the case, you can either:
+:::tip
+If you want to setup an ssh key and clone with git instead of https, you can:
 
 1. [Create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 2. [Connect to GitHub with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
-3. Clone with `https`. E.g.,
-
-```bash
-git clone https://github.com/farm-ng/farm-ng-amiga.git
-```
-
+3. Clone with `git clone git@github.com:farm-ng/farm-ng-amiga.git`
 :::
 
-### [Optional] Set up virtual environment
+### [Recommended] Set up virtual environment
 
 :::tip
 We recommend running the brain SDK applications in a virtual
@@ -145,7 +137,7 @@ If you want to edit the package, or contribute, you can install
 from source.
 
 Install `pip3` & setup a `virtualenv` (shown
-[above](#optional-set-up-virtual-environment))
+[above](#recommended-set-up-virtual-environment))
 
 Create and install the ``farm-ng-amiga`` Python package
 

--- a/website/docs/brain/brain-next-steps.md
+++ b/website/docs/brain/brain-next-steps.md
@@ -6,9 +6,7 @@ title: Next Steps
 :::caution Warning
 You will not be able to follow the examples and tutorials listed
 below if you have not downloaded the farm-ng-amiga repository.
-To download the repository navigate
-[**here**](/docs/brain/brain-install.md) and follow the
-instructions
+Please first follow the instructions at [Brain ADK Install](/docs/brain/brain-install.md).
 :::
 
 Now that you have downloaded the repository and have all the

--- a/website/docs/brain/custom-applications.mdx
+++ b/website/docs/brain/custom-applications.mdx
@@ -5,6 +5,12 @@ title: Developing Custom Applications
 
 # Developing Custom Applications
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 :::tip
 We now have a set of tutorials that walk you through creating custom applications that interact with cameras and drive your Amiga from the brain!
 

--- a/website/docs/brain/ros-bridge.md
+++ b/website/docs/brain/ros-bridge.md
@@ -6,6 +6,12 @@ title: Amiga ROS Bridge
 
 # Amiga ROS Bridge
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 ## [Link to `farm-ng/amiga-ros-bridge`](https://github.com/farm-ng/amiga-ros-bridge)
 
 This repository contains a ROS bridge for the Farm-ng Amiga platform written in [Rust](https://www.rust-lang.org/).

--- a/website/docs/examples/examples_index.md
+++ b/website/docs/examples/examples_index.md
@@ -106,6 +106,12 @@ install the
 
 ### [Record and Access data](/docs/examples/import_log_file/README.md)
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This example only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated example for brains running `v2.x` Amiga OS software.
+:::
+
 This tutorial walks you through recording field data and
 offloading it to your local machine.
 
@@ -141,6 +147,12 @@ followed in order.
 
 ### [00 - Tutorial Introduction](/docs/tutorials/introduction/tutorial-introduction)
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 This tutorial introduces necessary background knowledge and walks
 you through the
 [**`amiga-app-template`**](https://github.com/farm-ng/amiga-app-template).
@@ -151,6 +163,12 @@ The topics covered in this tutorial include:
 - GRPC / asyncio application development
 
 ### [01 - Camera Streamer Tutorial](/docs/tutorials/camera_streamer/camera-streamer-overview)
+
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
 
 This tutorial is designed to teach you to implement the
 `OakCameraClient` in a GUI application using
@@ -165,6 +183,12 @@ The topics covered in this tutorial include:
 - Streaming an Oak camera with the camera client
 
 ### [02 - Virtual Joystick Tutorial](/docs/tutorials/virtual_joystick/virtual-joystick-overview)
+
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
 
 This tutorial is designed to enable you to develop your own
 custom applications that uses camera streams and controls your
@@ -183,6 +207,23 @@ The topics covered in this tutorial include:
 
 ### [Developing Custom Applications](/docs/brain/custom-applications.mdx)
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 This takes you through the steps of creating your own app with
 the use of an app template and deploying and testing it on the
 Amiga.
+
+### [Amiga ROS Bridge](/docs/brain/ros-bridge.md)
+
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
+This takes you through the steps of setting up the Amiga ROS bridge
+for controlling the Amiga robot using your existing ROS nodes.

--- a/website/docs/examples/file_reader/README.md
+++ b/website/docs/examples/file_reader/README.md
@@ -21,6 +21,11 @@ example you can skip to [**set up**](#setup)
 
 ## Download the log file
 
+:::caution deprecation warning
+This log file comes from a brain running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated log file from a brain running `v2.x` Amiga OS software.
+:::
+
 Now you are going to download the log file that you will use in
 this example.
 [**Click here to download**](https://farm-ng-dev-auto-plot-mvp.s3.us-west-2.amazonaws.com/datasets/western-growers-2022-12-05/events_12052022115852.bin)
@@ -84,9 +89,15 @@ be RGB and one should be disparity (it might be hidden behind the
 RGB window so try moving the RGB window). You have now finished
 running this example!
 
+:::caution deprecation warning
+This log file comes from a brain running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated log file from a brain running `v2.x` Amiga OS software.
+:::
+
 If you want another log file to run here is an example of Amiga
 driving in a field
 [(click to download)](https://farm-ng-dev-auto-plot-mvp.s3.us-west-2.amazonaws.com/datasets/jacobs_freedom_1013/events_10132022112259.bin)
+
 :::tip
 There is another tutorial that walks you through getting data
 directly from the Amiga

--- a/website/docs/examples/file_reader_can/README.md
+++ b/website/docs/examples/file_reader_can/README.md
@@ -23,6 +23,11 @@ example you can skip to [**set up**](#setup)
 
 ## Download the log file
 
+:::caution deprecation warning
+This log file comes from a brain running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated log file from a brain running `v2.x` Amiga OS software.
+:::
+
 Now you are going to download the log file that you will use in
 this example.
 [**Click here to download**](https://farm-ng-dev-auto-plot-mvp.s3.us-west-2.amazonaws.com/datasets/western-growers-2022-12-05/events_12052022115852.bin)

--- a/website/docs/examples/import_log_file/README.md
+++ b/website/docs/examples/import_log_file/README.md
@@ -3,6 +3,12 @@ id: import-log-file
 title: Record and Access data
 ---
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This example only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated example for brains running `v2.x` Amiga OS software.
+:::
+
 # How to Record and Access data on the Amiga
 
 This tutorial will walk you through how to record field data and
@@ -13,6 +19,12 @@ transfer that data from the Amiga to your local machine.
 The first step in this tutorial is to record some field data. To
 do this, you are going to use the handy Recorder app on the
 Amiga. To learn how to use it, watch the video below (watch until 5:03)
+
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This video only applies to brains running Amiga OS `v1.x` versions.
+:::
+
 <iframe width="560" height="315"
 src="https://www.youtube.com/embed/_p0I11p4QF4?start=169"
 title="YouTube video player" frameborder="0"

--- a/website/docs/intelligence-kit/brain/brain-v2.md
+++ b/website/docs/intelligence-kit/brain/brain-v2.md
@@ -2,6 +2,12 @@
 id: brain-v2
 title: Brain v2.0
 ---
+
+:::info
+The Brain v2.0 tag here refers to the **hardware** version of the brain
+and is not mutually exclusive with Amiga OS software versioning.
+:::
+
 # Brain v2.0
 
 [Buy it on Farm-ng Shop](https://farm-ng.com/products/brain)
@@ -11,6 +17,11 @@ title: Brain v2.0
 ## [Brain product page](https://farm-ng.com/products/brain)
 
 ### Brain overview video
+
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This video only applies to brains running Amiga OS `v1.x` versions.
+:::
 
 <iframe width="560"
 height="315"

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -212,6 +212,11 @@ title: Frequently Asked Questions
   <summary>Why are other apps launching over the app I'm currently using?
   </summary>
   <div>
+    **deprecation warning**<br/>
+    This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+    This video only applies to brains running Amiga OS `v1.x` versions.<br/>
+    **end warning**<br/>
+    <br/><br/>
     If you launch an app with the command line using an <code>entry.sh</code> script,
     it is currently possible to have touch interactions with the launcher behind.
     This will cause other installed apps to unexpectedly launch over the app you are trying to use.

--- a/website/docs/tutorials/camera_streamer/00_intro.md
+++ b/website/docs/tutorials/camera_streamer/00_intro.md
@@ -5,6 +5,12 @@ title: 00 - Camera Streamer Overview
 
 # Camera Streamer Overview
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 :::tip
 This tutorial builds off of the
 [**Tutorial Introduction**](/docs/tutorials/introduction/tutorial-introduction),

--- a/website/docs/tutorials/camera_streamer/01_template_starter.md
+++ b/website/docs/tutorials/camera_streamer/01_template_starter.md
@@ -4,6 +4,12 @@ title: 01 - Template Starter
 ---
 # Template Starter
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 ## Set up your Amiga brain template
 
 Follow the instructions in [**Developing Custom Applications**](/docs/brain/custom-applications.mdx)

--- a/website/docs/tutorials/camera_streamer/02_kivy_definition.md
+++ b/website/docs/tutorials/camera_streamer/02_kivy_definition.md
@@ -4,6 +4,12 @@ title: 02 - Kivy Definition
 ---
 # Kivy Definition
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 :::info
 In the [**`src/res/main.kv`**](https://github.com/farm-ng/camera-streamer/blob/main/src/res/main.kv)
 file of the

--- a/website/docs/tutorials/camera_streamer/03_camera_stream.md
+++ b/website/docs/tutorials/camera_streamer/03_camera_stream.md
@@ -4,6 +4,12 @@ title: 03 - Python Implementation
 ---
 # Python Implementation
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 :::info
 The Python implementation of the
 [**camera-streamer**](https://github.com/farm-ng/camera-streamer)

--- a/website/docs/tutorials/introduction/00_tutorial_intro.md
+++ b/website/docs/tutorials/introduction/00_tutorial_intro.md
@@ -4,6 +4,12 @@ title: 00 - Introduction
 ---
 # Tutorial Introduction
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 This first tutorial is designed to provide you with:
 
 1. References and the basic background knowledge that your Amiga

--- a/website/docs/tutorials/introduction/01_background_knowledge.md
+++ b/website/docs/tutorials/introduction/01_background_knowledge.md
@@ -4,6 +4,12 @@ title: 01 - Background Knowledge
 ---
 # Background knowledge
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 The Amiga brain app development meets at the intersection of three key libraries,
 as well as a few publicly available libraries developed by the **farm-ng** team:
 

--- a/website/docs/tutorials/introduction/02_template_overview.md
+++ b/website/docs/tutorials/introduction/02_template_overview.md
@@ -4,6 +4,12 @@ title: 02 - Template Overview
 ---
 # Template Overview
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 This section explains all of the Python and kivy code in the
 [**`amiga-app-template`**](https://github.com/farm-ng/amiga-app-template),
 to help understand the base before you add anything custom.

--- a/website/docs/tutorials/virtual_joystick/00_overview.md
+++ b/website/docs/tutorials/virtual_joystick/00_overview.md
@@ -5,6 +5,12 @@ title: 00 - Virtual Joystick Overview
 
 # Virtual Joystick Overview
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 :::tip
 This tutorial builds off of the
 [**Tutorial Introduction**](/docs/tutorials/introduction/tutorial-introduction) and the

--- a/website/docs/tutorials/virtual_joystick/01_template_starter.md
+++ b/website/docs/tutorials/virtual_joystick/01_template_starter.md
@@ -4,6 +4,12 @@ title: 01 - Template Starter
 ---
 # Template Starter
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 ## Set up your Amiga brain template
 
 Follow the instructions in [**Developing Custom Applications**](/docs/brain/custom-applications.mdx)

--- a/website/docs/tutorials/virtual_joystick/02_device_streams.md
+++ b/website/docs/tutorials/virtual_joystick/02_device_streams.md
@@ -4,6 +4,12 @@ title: 02 - Device Streams
 ---
 # Device Streams
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 :::info
 In the
 [**`src/res/main.kv`**](https://github.com/farm-ng/virtual-joystick/blob/main/src/res/main.kv)

--- a/website/docs/tutorials/virtual_joystick/03_virtual_joystick_widget.md
+++ b/website/docs/tutorials/virtual_joystick/03_virtual_joystick_widget.md
@@ -4,6 +4,12 @@ title: 03 - Virtual Joystick Widget
 ---
 # Virtual Joystick Widget
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 We will now define a custom widget, the `VirtualJoystickWidget`,
 in kivy and Python to give an introduction to kivy drawing.
 We define the custom widget such that it can be imported just

--- a/website/docs/tutorials/virtual_joystick/04_auto_control.md
+++ b/website/docs/tutorials/virtual_joystick/04_auto_control.md
@@ -4,6 +4,12 @@ title: 04 - Auto Control
 ---
 # Auto Control
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 Finally, we will use this virtual joystick and the canbus
 client / service connection to control the Amiga to complete the
 full Virtual Joystick example.

--- a/website/docs/tutorials/virtual_joystick/05_further_exercises.md
+++ b/website/docs/tutorials/virtual_joystick/05_further_exercises.md
@@ -4,6 +4,12 @@ title: 05 - Further Exercises
 ---
 # Further Exercises
 
+:::caution deprecation warning
+This is out-of-date for brains running `v2.x` Amiga OS software.<br/>
+This tutorial only applies to brains running Amiga OS `v1.x` versions.<br/>
+Please check back for an updated tutorial for brains running `v2.x` Amiga OS software.
+:::
+
 Optionally, go beyond the tutorial and try to add features to this example.
 Two options are:
 


### PR DESCRIPTION
These serve as a clear indicator of where we need to update the docs.

Search for `deprecation warning` with this repository open in VS Code and we can find all places where we need to update docs for the transition.