### PR TITLE
Doc: Remove repeated lines in Dashboard index

### DIFF
--- a/website/docs/dashboard/README.md
+++ b/website/docs/dashboard/README.md
@@ -17,15 +17,6 @@ allowfullscreen></iframe>
 
 ## Description
 
-Farm-ng's Dashboard is a ruggedized, waterproof, outdoor-visible touch-screen display
-and machine controller - customizable through our ADK (Amiga-Dev-Kit) toolset!
-
-Under the hood is a simple yet powerful embedded microcontroller based on Adafruit's Feather M4 CAN,
-which runs CircuitPython and makes building your own custom interfaces as simple as connecting
-a USB cable and writing a few lines of code.
-If you've been looking for a microcontroller and display that can handle harsh environments,
-look no further!
-
 Farm-ng's Dashboard is a ruggedized, waterproof, outdoor-visible
 touch-screen display and machine controller - customizable
 through our ADK (Amiga-Dev-Kit) toolset!


### PR DESCRIPTION
Deleted blocks are repeated immediately after. The latter variant is fixed-column-width formatted so chose to keep that one.